### PR TITLE
feat: add major version distribution pie chart

### DIFF
--- a/src/components/PackageResults/MajorVersionChart.tsx
+++ b/src/components/PackageResults/MajorVersionChart.tsx
@@ -4,7 +4,6 @@ import {
   Pie,
   Cell,
   Tooltip,
-  Legend,
   ResponsiveContainer,
 } from "recharts";
 import semver from "semver";
@@ -100,19 +99,19 @@ const MajorVersionChart: React.FC<MajorVersionChartProps> = ({ versions }) => {
   }, [versions]);
 
   return (
-    <div className="w-full min-h-[300px] flex flex-col">
-      <h3 className="text-sm font-medium text-[var(--color-text-muted)] mb-4 text-center flex-none">
+    <div className="w-full flex flex-col gap-3">
+      <h3 className="text-sm font-medium text-[var(--color-text-muted)] text-center">
         Major Version Distribution
       </h3>
-      <div className="flex-1 min-h-0" style={{ height: "260px" }}>
-        <ResponsiveContainer width="100%" height="100%">
+      <div style={{ height: 220 }}>
+        <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <PieChart>
             <Pie
               data={data}
               cx="50%"
               cy="50%"
               labelLine={false}
-              outerRadius={100}
+              outerRadius={90}
               fill="#8884d8"
               dataKey="value"
             >
@@ -124,9 +123,19 @@ const MajorVersionChart: React.FC<MajorVersionChartProps> = ({ versions }) => {
               ))}
             </Pie>
             <Tooltip content={<CustomTooltip />} />
-            <Legend />
           </PieChart>
         </ResponsiveContainer>
+      </div>
+      <div className="flex flex-wrap gap-x-3 gap-y-1.5 justify-center">
+        {data.map((entry, index) => (
+          <div key={entry.name} className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
+            <span
+              className="w-2.5 h-2.5 rounded-sm flex-none"
+              style={{ backgroundColor: COLORS[index % COLORS.length] }}
+            />
+            <span>{entry.name}</span>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/PackageResults/MajorVersionChart.tsx
+++ b/src/components/PackageResults/MajorVersionChart.tsx
@@ -7,13 +7,13 @@ import {
   Legend,
   ResponsiveContainer,
 } from "recharts";
+import semver from "semver";
 import { VersionWithPercentage } from "./types";
 
-interface PopularityChartProps {
+interface MajorVersionChartProps {
   versions: VersionWithPercentage[];
 }
 
-// Modern indigo/violet palette with complementary colors
 const COLORS = [
   "#6366f1", // indigo-500
   "#8b5cf6", // violet-500
@@ -49,31 +49,48 @@ const CustomTooltip = ({
   return null;
 };
 
-const PopularityChart: React.FC<PopularityChartProps> = ({ versions }) => {
+const MajorVersionChart: React.FC<MajorVersionChartProps> = ({ versions }) => {
   const data = useMemo(() => {
-    // Sort by downloads descending
-    const sorted = [...versions].sort((a, b) => b.downloads - a.downloads);
+    const majorMap = new Map<number, { downloads: number; percentage: number }>();
+
+    for (const v of versions) {
+      try {
+        const major = semver.major(v.version);
+        const existing = majorMap.get(major);
+        if (existing) {
+          existing.downloads += v.downloads;
+          existing.percentage += v.percentage;
+        } else {
+          majorMap.set(major, {
+            downloads: v.downloads,
+            percentage: v.percentage,
+          });
+        }
+      } catch {
+        // skip versions that semver cannot parse
+      }
+    }
+
+    const sorted = Array.from(majorMap.entries())
+      .map(([major, { downloads, percentage }]) => ({
+        name: `^${major}`,
+        value: downloads,
+        percentage: parseFloat(percentage.toFixed(2)),
+      }))
+      .sort((a, b) => b.value - a.value);
 
     if (sorted.length <= 9) {
-      return sorted.map((v) => ({
-        name: v.version,
-        value: v.downloads,
-        percentage: v.percentage,
-      }));
+      return sorted;
     }
 
     const top9 = sorted.slice(0, 9);
     const others = sorted.slice(9);
 
-    const othersDownloads = others.reduce((sum, v) => sum + v.downloads, 0);
+    const othersDownloads = others.reduce((sum, v) => sum + v.value, 0);
     const othersPercentage = others.reduce((sum, v) => sum + v.percentage, 0);
 
     return [
-      ...top9.map((v) => ({
-        name: v.version,
-        value: v.downloads,
-        percentage: v.percentage,
-      })),
+      ...top9,
       {
         name: "Others",
         value: othersDownloads,
@@ -85,7 +102,7 @@ const PopularityChart: React.FC<PopularityChartProps> = ({ versions }) => {
   return (
     <div className="w-full min-h-[300px] flex flex-col">
       <h3 className="text-sm font-medium text-[var(--color-text-muted)] mb-4 text-center flex-none">
-        Version Distribution
+        Major Version Distribution
       </h3>
       <div className="flex-1 min-h-0" style={{ height: "260px" }}>
         <ResponsiveContainer width="100%" height="100%">
@@ -95,7 +112,7 @@ const PopularityChart: React.FC<PopularityChartProps> = ({ versions }) => {
               cx="50%"
               cy="50%"
               labelLine={false}
-              outerRadius={120}
+              outerRadius={100}
               fill="#8884d8"
               dataKey="value"
             >
@@ -115,4 +132,4 @@ const PopularityChart: React.FC<PopularityChartProps> = ({ versions }) => {
   );
 };
 
-export default PopularityChart;
+export default MajorVersionChart;

--- a/src/components/PackageResults/MajorVersionChart.tsx
+++ b/src/components/PackageResults/MajorVersionChart.tsx
@@ -14,16 +14,16 @@ interface MajorVersionChartProps {
 }
 
 const COLORS = [
-  "#6366f1", // indigo-500
-  "#8b5cf6", // violet-500
-  "#a855f7", // purple-500
-  "#ec4899", // pink-500
-  "#f43f5e", // rose-500
+  "#3b82f6", // blue-500
   "#f97316", // orange-500
-  "#eab308", // yellow-500
   "#22c55e", // green-500
-  "#14b8a6", // teal-500
+  "#ef4444", // red-500
+  "#eab308", // yellow-500
+  "#8b5cf6", // violet-500
   "#06b6d4", // cyan-500
+  "#ec4899", // pink-500
+  "#84cc16", // lime-500
+  "#f59e0b", // amber-500
 ];
 
 const CustomTooltip = ({

--- a/src/components/PackageResults/PackageResults.tsx
+++ b/src/components/PackageResults/PackageResults.tsx
@@ -116,15 +116,15 @@ const PackageResults: React.FC<PackageResultsProps> = ({
               <hr className="border-t mt-4" />
             </div>
 
-            <div className="flex-1 min-h-0 flex flex-col lg:flex-row overflow-hidden">
-              <div className="w-full lg:w-2/3 h-full flex flex-col min-h-0 lg:border-r lg:pr-6">
+            <div className="flex flex-col lg:flex-row">
+              <div className="w-full lg:w-2/3 lg:border-r lg:pr-6">
                 <VersionsTable
                   versions={filteredVersions}
                   pageSize={pageSize}
                   onPageSizeChange={setPageSize}
                 />
               </div>
-              <div className="w-full lg:w-1/3 lg:pl-6 lg:overflow-y-auto">
+              <div className="w-full lg:w-1/3 lg:pl-6">
                 <div className="flex flex-col gap-8">
                   <PopularityChart versions={filteredVersions} />
                   <MajorVersionChart versions={filteredVersions} />

--- a/src/components/PackageResults/PackageResults.tsx
+++ b/src/components/PackageResults/PackageResults.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_PAGE_SIZE } from "./constants";
 import PackageHeader from "./PackageHeader";
 import VersionsTable from "./VersionsTable";
 import PopularityChart from "./PopularityChart";
+import MajorVersionChart from "./MajorVersionChart";
 
 const PackageResults: React.FC<PackageResultsProps> = ({
   packageInfo,
@@ -123,8 +124,11 @@ const PackageResults: React.FC<PackageResultsProps> = ({
                   onPageSizeChange={setPageSize}
                 />
               </div>
-              <div className="w-full lg:w-1/3 h-full lg:pl-6">
-                <PopularityChart versions={filteredVersions} />
+              <div className="w-full lg:w-1/3 lg:pl-6 lg:overflow-y-auto">
+                <div className="flex flex-col gap-8">
+                  <PopularityChart versions={filteredVersions} />
+                  <MajorVersionChart versions={filteredVersions} />
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/PackageResults/PopularityChart.tsx
+++ b/src/components/PackageResults/PopularityChart.tsx
@@ -4,7 +4,6 @@ import {
   Pie,
   Cell,
   Tooltip,
-  Legend,
   ResponsiveContainer,
 } from "recharts";
 import { VersionWithPercentage } from "./types";
@@ -83,19 +82,19 @@ const PopularityChart: React.FC<PopularityChartProps> = ({ versions }) => {
   }, [versions]);
 
   return (
-    <div className="w-full min-h-[300px] flex flex-col">
-      <h3 className="text-sm font-medium text-[var(--color-text-muted)] mb-4 text-center flex-none">
+    <div className="w-full flex flex-col gap-3">
+      <h3 className="text-sm font-medium text-[var(--color-text-muted)] text-center">
         Version Distribution
       </h3>
-      <div className="flex-1 min-h-0" style={{ height: "260px" }}>
-        <ResponsiveContainer width="100%" height="100%">
+      <div style={{ height: 220 }}>
+        <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <PieChart>
             <Pie
               data={data}
               cx="50%"
               cy="50%"
               labelLine={false}
-              outerRadius={120}
+              outerRadius={90}
               fill="#8884d8"
               dataKey="value"
             >
@@ -107,9 +106,19 @@ const PopularityChart: React.FC<PopularityChartProps> = ({ versions }) => {
               ))}
             </Pie>
             <Tooltip content={<CustomTooltip />} />
-            <Legend />
           </PieChart>
         </ResponsiveContainer>
+      </div>
+      <div className="flex flex-wrap gap-x-3 gap-y-1.5 justify-center">
+        {data.map((entry, index) => (
+          <div key={entry.name} className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
+            <span
+              className="w-2.5 h-2.5 rounded-sm flex-none"
+              style={{ backgroundColor: COLORS[index % COLORS.length] }}
+            />
+            <span>{entry.name}</span>
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
Add a second pie chart below the existing version distribution chart that groups downloads by major version, labeled in semver caret format (^5, ^4, etc.).

https://claude.ai/code/session_01DpRcVvk4bj6F6am6SGu8hN