### PR TITLE
fix: make layout responsive with proper scrolling

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -9,7 +9,7 @@ interface AppLayoutProps {
 
 const AppLayout: React.FC<AppLayoutProps> = ({ children, onLogoClick }) => {
   return (
-    <div className="h-screen w-full flex flex-col bg-[var(--color-bg)] overflow-hidden">
+    <div className="h-screen w-full flex flex-col bg-[var(--color-bg)]">
       <header className="flex-none flex items-center justify-between px-6 py-3 border-b border-[var(--color-border)]">
         <button
           onClick={onLogoClick}
@@ -20,8 +20,8 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children, onLogoClick }) => {
         <ThemeToggle />
       </header>
 
-      <main className="flex-1 w-full overflow-hidden flex flex-col">
-        <div className="max-w-7xl w-full mx-auto px-6 text-[var(--color-text)] h-full flex flex-col py-6">
+      <main className="flex-1 w-full overflow-auto flex flex-col custom-scrollbar">
+        <div className="max-w-7xl w-full mx-auto px-6 text-[var(--color-text)] flex-1 flex flex-col py-6">
           {children}
         </div>
       </main>

--- a/src/components/PackageResults/PackageResults.tsx
+++ b/src/components/PackageResults/PackageResults.tsx
@@ -98,10 +98,10 @@ const PackageResults: React.FC<PackageResultsProps> = ({
   );
 
   return (
-    <div className="h-full w-full flex flex-col min-h-0">
-      <Card className="h-full flex flex-col border-none shadow-none">
-        <CardContent className="p-6 h-full flex flex-col min-h-0">
-          <div className="h-full flex flex-col space-y-4">
+    <div className="w-full flex flex-col">
+      <Card className="flex flex-col border-none shadow-none">
+        <CardContent className="p-6 flex flex-col">
+          <div className="flex flex-col space-y-4">
             <div className="flex-none">
               <PackageHeader
                 packageName={packageInfo.name}
@@ -124,7 +124,7 @@ const PackageResults: React.FC<PackageResultsProps> = ({
                   onPageSizeChange={setPageSize}
                 />
               </div>
-              <div className="w-full lg:w-1/3 lg:pl-6">
+              <div className="w-full lg:w-1/3 lg:pl-6 mt-6 lg:mt-0">
                 <div className="flex flex-col gap-8">
                   <PopularityChart versions={filteredVersions} />
                   <MajorVersionChart versions={filteredVersions} />

--- a/src/components/PackageResults/VersionsTable.tsx
+++ b/src/components/PackageResults/VersionsTable.tsx
@@ -82,7 +82,7 @@ const VersionsTable: React.FC<VersionsTableProps> = ({
   };
 
   return (
-    <div className="space-y-4 h-full flex flex-col min-h-0">
+    <div className="space-y-4 flex flex-col">
       <div className="flex-1">
         <Table>
           <TableHeader className="sticky top-0 bg-background z-10">


### PR DESCRIPTION
Remove overflow-hidden constraints that prevented scrolling when content exceeded viewport. Replace rigid h-full/min-h-0 sizing with natural content flow. Charts stack vertically on small screens, sit side-by-side on lg+.