### PR TITLE
Add formal versions filter toggle with URL state management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ const AppContent: React.FC = () => {
   const { params, setParam, resetParams } = useSearchParams({
     q: "",
     filter: "",
+    formal: false,
   });
 
   const {
@@ -53,6 +54,11 @@ const AppContent: React.FC = () => {
     setParam("filter", filter);
   };
 
+  // Handle formal-only toggle
+  const handleFormalOnlyChange = (formalOnly: boolean) => {
+    setParam("formal", formalOnly);
+  };
+
   // Handle logo click to reset the app to home state
   const handleLogoClick = () => {
     resetSearch();
@@ -79,6 +85,8 @@ const AppContent: React.FC = () => {
           packageInfo={packageInfo}
           versionFilter={params.filter}
           onVersionFilterChange={handleVersionFilterChange}
+          formalOnly={params.formal}
+          onFormalOnlyChange={handleFormalOnlyChange}
         />
       );
     }
@@ -101,6 +109,8 @@ const AppContent: React.FC = () => {
         isCompact={showCompactSearch}
         onVersionFilter={packageInfo ? handleVersionFilterChange : undefined}
         versionFilter={params.filter}
+        formalOnly={params.formal}
+        onFormalOnlyChange={packageInfo ? handleFormalOnlyChange : undefined}
       />
       {renderContent()}
     </AppLayout>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ const AppContent: React.FC = () => {
   const { params, setParam, resetParams } = useSearchParams({
     q: "",
     filter: "",
-    formal: false,
+    formal: true,
   });
 
   const {

--- a/src/components/PackageResults/PackageResults.tsx
+++ b/src/components/PackageResults/PackageResults.tsx
@@ -12,14 +12,22 @@ const PackageResults: React.FC<PackageResultsProps> = ({
   packageInfo,
   versionFilter = "",
   onVersionFilterChange,
+  formalOnly = false,
+  onFormalOnlyChange,
 }) => {
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
 
   // Apply semver filter to versions
   const filteredVersions = useMemo(() => {
-    const versionsWithDownloads = packageInfo.versions.filter(
+    let versionsWithDownloads = packageInfo.versions.filter(
       (version) => version.downloads > 0
     );
+
+    if (formalOnly) {
+      versionsWithDownloads = versionsWithDownloads.filter(
+        (v) => semver.valid(v.version) && semver.prerelease(v.version) === null
+      );
+    }
 
     if (!versionFilter) {
       return versionsWithDownloads.map((version) => {
@@ -94,7 +102,8 @@ const PackageResults: React.FC<PackageResultsProps> = ({
 
   // Determine if filter is active
   const isFilterActive = Boolean(
-    versionFilter && filteredVersions.length !== packageInfo.versions.length
+    (versionFilter || formalOnly) &&
+      filteredVersions.length !== packageInfo.versions.length
   );
 
   return (
@@ -111,6 +120,8 @@ const PackageResults: React.FC<PackageResultsProps> = ({
                 filterCount={filteredVersions.length}
                 versionFilter={versionFilter}
                 onVersionFilterChange={onVersionFilterChange}
+                formalOnly={formalOnly}
+                onFormalOnlyChange={onFormalOnlyChange}
               />
 
               <hr className="border-t mt-4" />

--- a/src/components/PackageResults/types.ts
+++ b/src/components/PackageResults/types.ts
@@ -4,6 +4,8 @@ export interface PackageResultsProps {
   packageInfo: PackageInfo;
   versionFilter?: string;
   onVersionFilterChange?: (filter: string) => void;
+  formalOnly?: boolean;
+  onFormalOnlyChange?: (formalOnly: boolean) => void;
 }
 
 export interface VersionWithPercentage extends PackageVersion {
@@ -18,4 +20,6 @@ export interface PackageHeaderProps {
   filterCount: number;
   versionFilter: string;
   onVersionFilterChange?: (filter: string) => void;
+  formalOnly?: boolean;
+  onFormalOnlyChange?: (formalOnly: boolean) => void;
 }

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -10,6 +10,8 @@ interface SearchBoxProps {
   isCompact?: boolean;
   onVersionFilter?: (filter: string) => void;
   versionFilter?: string;
+  formalOnly?: boolean;
+  onFormalOnlyChange?: (formalOnly: boolean) => void;
 }
 
 const SearchBox: React.FC<SearchBoxProps> = ({
@@ -20,6 +22,8 @@ const SearchBox: React.FC<SearchBoxProps> = ({
   isCompact = false,
   onVersionFilter,
   versionFilter,
+  formalOnly = false,
+  onFormalOnlyChange,
 }) => {
   if (isCompact) {
     return (
@@ -32,15 +36,31 @@ const SearchBox: React.FC<SearchBoxProps> = ({
             isLoading={isLoading}
           />
         </div>
-        {onVersionFilter && (
-          <div className="flex-[1_0_200px] max-w-sm ml-auto">
-            <VersionFilterInput
-              onVersionFilter={onVersionFilter}
-              versionFilter={versionFilter}
-              isLoading={isLoading}
-            />
-          </div>
-        )}
+        <div className="flex items-center gap-2 flex-wrap ml-auto">
+          {onFormalOnlyChange && (
+            <button
+              onClick={() => onFormalOnlyChange(!formalOnly)}
+              disabled={isLoading}
+              title="Show only formal (stable) releases without pre-release tags"
+              className={`h-9 px-3 text-xs rounded-md border transition-colors flex items-center gap-1.5 ${
+                formalOnly
+                  ? "bg-[var(--color-primary)] text-[var(--color-primary-foreground)] border-[var(--color-primary)] hover:bg-[var(--color-primary)]/90"
+                  : "bg-[var(--color-bg)] text-[var(--color-text-muted)] border-[var(--color-border)] hover:bg-[var(--color-bg-subtle)] hover:text-[var(--color-text)]"
+              } disabled:opacity-40 disabled:pointer-events-none`}
+            >
+              Formal only
+            </button>
+          )}
+          {onVersionFilter && (
+            <div className="flex-[1_0_200px] max-w-sm">
+              <VersionFilterInput
+                onVersionFilter={onVersionFilter}
+                versionFilter={versionFilter}
+                isLoading={isLoading}
+              />
+            </div>
+          )}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Adds a "Formal only" toggle button in the compact search bar that filters
out pre-release versions (alpha, beta, rc, etc.), keeping only stable
semver releases. The toggle state is persisted in the URL via the `formal`
query parameter so it can be bookmarked and shared.

Closes #14

https://claude.ai/code/session_0156vE69HCHkjpvY2oNPTCuw