### PR TITLE
Fix stale search results and reset behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ const AppContent: React.FC = () => {
     searchTerm,
     setSearchTerm,
     searchPackage,
+    resetSearch,
     loading,
     error,
     packageInfo,
@@ -65,6 +66,7 @@ const AppContent: React.FC = () => {
   // Handle logo click to reset the app to home state
   const handleLogoClick = () => {
     setSearchTerm("");
+    resetSearch();
     resetParams();
   };
 
@@ -75,7 +77,8 @@ const AppContent: React.FC = () => {
           errorMessage={error}
           onReset={() => {
             setSearchTerm("");
-            setParam("q", "");
+            resetSearch();
+            resetParams();
           }}
         />
       );

--- a/src/hooks/usePackageSearch.ts
+++ b/src/hooks/usePackageSearch.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { fetchPackageInfo, PackageInfo } from "../services/npmService";
 
 interface PackageSearchState {
@@ -9,6 +9,7 @@ interface PackageSearchState {
 }
 
 export const usePackageSearch = () => {
+  const requestIdRef = useRef(0);
   const [searchTerm, setSearchTerm] = useState("");
   const [state, setState] = useState<PackageSearchState>({
     loading: false,
@@ -17,7 +18,9 @@ export const usePackageSearch = () => {
     hasSearched: false,
   });
 
-  const searchPackage = async (packageName: string) => {
+  const searchPackage = useCallback(async (packageName: string) => {
+    const requestId = ++requestIdRef.current;
+
     if (!packageName.trim()) {
       setState({
         loading: false,
@@ -37,6 +40,8 @@ export const usePackageSearch = () => {
 
     try {
       const packageInfo = await fetchPackageInfo(packageName);
+      if (requestId !== requestIdRef.current) return;
+
       setState({
         loading: false,
         error: null,
@@ -44,6 +49,8 @@ export const usePackageSearch = () => {
         hasSearched: true,
       });
     } catch (error) {
+      if (requestId !== requestIdRef.current) return;
+
       setState({
         loading: false,
         error:
@@ -54,17 +61,19 @@ export const usePackageSearch = () => {
         hasSearched: true,
       });
     }
-  };
+  }, []);
 
   // Reset the search state to default values
-  const resetSearch = () => {
+  const resetSearch = useCallback(() => {
+    // Invalidate pending requests so they cannot restore stale results.
+    requestIdRef.current += 1;
     setState({
       loading: false,
       error: null,
       packageInfo: null,
       hasSearched: false,
     });
-  };
+  }, []);
 
   return {
     searchTerm,


### PR DESCRIPTION
### Motivation
- Prevent older overlapping search requests from overwriting newer results and ensure the app clears results and errors when returning home or dismissing an error.

### Description
- Add a `requestIdRef` (`useRef`) to `usePackageSearch` and bind it to each `searchPackage` call to identify and ignore stale responses.
- Stabilize callbacks by wrapping `searchPackage` and `resetSearch` in `useCallback` and early-return when a response is no longer current.
- Invalidate pending requests in `resetSearch` by bumping `requestIdRef` so late responses cannot repopulate cleared state.
- Wire the `resetSearch` call into `src/App.tsx` so logo clicks and error-dismiss actions call `resetSearch()` and `resetParams()` together to fully clear UI and URL state.

### Testing
- Ran `bun run lint` and it completed successfully.
- Ran `bun run build` and build completed successfully with only the standard Vite chunk-size warning.
- Ran `git diff --check` and static checks passed (no whitespace/errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6dfeaa7b54832c8a5e0e9554cf8496)